### PR TITLE
TFIFT-11453

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -123,7 +123,7 @@ export interface JAppPrintState {
   isDateVisible: boolean
   isNorthArrowVisible: boolean
   isScaleVisible: boolean
-  isLegend: boolean
+  isLegendVisible: boolean
   isHiResolution: boolean
   legendTitle: string
   legendSubTitle: string
@@ -358,6 +358,8 @@ export interface JAppPrintService {
   isDateVisibile(): boolean
   setNorthArrowVisibility(isVisible: boolean): void
   isNorthArrowVisible(): boolean
+  setLegendVisibility(isVisible: boolean): void
+  isLegendVisible(): boolean
   getAllPaperFormats(): JAppPaperFormat[]
   setPaperFormat(format: JAppPaperFormat | string): void
   getPaperFormat(): JAppPaperFormat

--- a/public/app.d.ts
+++ b/public/app.d.ts
@@ -2267,6 +2267,36 @@ declare namespace JMap {
       function setNorthArrowVisibility(isVisible: boolean): void
 
       /**
+       * **JMap.Application.Print.isLegendVisible**
+       *
+       * Returns true if the legend is displayed in the print layout.
+       *
+       * @example
+       * ```ts
+       * // returns true if the legend is visible
+       * JMap.Application.Print.isLegendVisible()
+       * ```
+       */
+      function isLegendVisible(): boolean
+
+      /**
+       * **JMap.Application.Print.setLegendVisibility**
+       *
+       * Sets the legend visible or hidden in the print layout.
+       *
+       * @param isVisible true to display, false to hide
+       * @example
+       * ```ts
+       * // Hide the legend
+       * JMap.Application.Print.setLegendVisibility(false)
+       *
+       * // Show the legend
+       * JMap.Application.Print.setLegendVisibility(true)
+       * ```
+       */
+      function setLegendVisibility(isVisible: boolean): void
+
+      /**
        * **JMap.Application.Print.getAllPaperFormats**
        *
        * Returns all available paper formats.


### PR DESCRIPTION
## Summary
- Add `setLegendVisibility` and `isLegendVisible` methods to `JAppPrintService` interface
- Add corresponding JSDoc declarations in `public/app.d.ts` for `JMap.Application.Print`
- Paired with jmapserver-ng PR for the print legend feature

## Test plan
- [ ] jmapserver-ng compiles against these type changes
- [ ] `JMap.Application.Print.setLegendVisibility()` and `isLegendVisible()` are available at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)